### PR TITLE
画像の保存先ディレクトリ作成コマンドを修正

### DIFF
--- a/plant-observation/kit.md
+++ b/plant-observation/kit.md
@@ -367,7 +367,7 @@ http://raspberrypi.local/cgi-bin/camera
 まず保存するディレクトリを作成して、アクセス権限を変更します。
 
 ```
-pi@raspberrypi:~ $ sudo mkdir /var/www/html/image
+pi@raspberrypi:~ $ sudo mkdir /var/www/html/images
 pi@raspberrypi:~ $ sudo chown -R pi:pi /var/www/html/
 ```
 


### PR DESCRIPTION
`http://soracom-files.s3.amazonaws.com/take_picture.sh`で指定されているディレクトリ名は`/var/www/html/images/`でした。

``` bash
echo "taking picture ... "
cd /var/www/html/images/
filename=$(date +%Y%m%d%H%M.jpg)
fswebcam -r 640x480 --title "Temperature: $temp (c)" $filename

ln -sf /var/www/html/images/$filename /var/www/html/image.jpg
```
