### PR TITLE
Install libssl-dev and remove request, elasticsearch

### DIFF
--- a/ultrasonic-sensor/kit.md
+++ b/ultrasonic-sensor/kit.md
@@ -573,17 +573,14 @@ SORACOM Harvest を使うには、Group の設定で、Harvest を有効にす�
 
 #### コマンド
 ```
-sudo apt-get install -y python-pip
-sudo pip install request
+sudo apt-get install -y python-pip libssl-dev
 curl -O http://soracom-files.s3.amazonaws.com/send_to_harvest.py
 python send_to_harvest.py
 ```
 
 #### 実行結果
 ```
-pi@raspberrypi:~ $ sudo apt-get install -y python-pip  
-:
-pi@raspberrypi ~ $ sudo pip install elasticsearch
+pi@raspberrypi:~ $ sudo apt-get install -y python-pip libssl-dev
 :
 pi@raspberrypi:~ $ curl -O http://soracom-files.s3.amazonaws.com/send_to_harvest.py
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current


### PR DESCRIPTION
@ma2shita @j3tm0t0 

距離測定センサーのハンズオンテキストの手順をやってみるとエラーになった点があったので修正してみました。ご確認お願いしますー

 - `sudo pip install request` はrequestsのtypoだと思われるが、requestsはデフォルトでインストールされているので削除。
 - `sudo pip install elasticsearch` はrequest(requests)のtypoだと思われるが同様の理由で削除。

 - また、import requestsすると以下のエラーになったため、libssl-devをインストールするようにした。
```
cffi.ffiplatform.VerificationError: importing '/usr/lib/python2.7/dist-packages/cryptography/_Cryptography_cffi_813c10e0x7adb75f8.arm-linux-gnueabihf.so': /usr/lib/python2.7/dist-packages/cryptography/_Cryptography_cffi_813c10e0x7adb75f8.arm-linux-gnueabihf.so: symbol SSLv2_client_method, version OPENSSL_1.0.0 not defined in file libssl.so.1.0.0 with link time reference```